### PR TITLE
Surface crawlAsync errors through the Stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.2
+
+- `crawlAsync` surfaces exceptions while crawling through the result stream
+  rather than as uncaught asynchronous errors.
+
 # 0.1.1
 
 - `crawlAsync` will now ignore nodes that are resolved to `null`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: graphs
-version: 0.1.1
+version: 0.1.2
 description: Graph algorithms operation an graphs in any representation.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/graphs

--- a/test/crawl_async_test.dart
+++ b/test/crawl_async_test.dart
@@ -84,5 +84,23 @@ void main() {
       ]);
       expect(result, ['a']);
     });
+
+    test('surfaces exceptions for crawling children', () {
+      var graph = {
+        'a': ['b'],
+      };
+      var nodes = crawlAsync(['a'], (n) => n,
+          (k, n) => k == 'b' ? throw new ArgumentError() : graph[k]);
+      expect(nodes, emitsThrough(emitsError(isArgumentError)));
+    });
+
+    test('surfaces exceptions for resolving keys', () {
+      var graph = {
+        'a': ['b'],
+      };
+      var nodes = crawlAsync(['a'],
+          (n) => n == 'b' ? throw new ArgumentError() : n, (k, n) => graph[k]);
+      expect(nodes, emitsThrough(emitsError(isArgumentError)));
+    });
   });
 }


### PR DESCRIPTION
Also use `eagerError` and check for alrady closed streams to prune work
when there are errors.