### PR TITLE
Update for Dart 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: dart
 dart:
   - dev
+  - stable
 
 dart_task:
   - test

--- a/example/crawl_async_example.dart
+++ b/example/crawl_async_example.dart
@@ -29,14 +29,12 @@ Future<AnalysisContext> get analysisContext async {
     var libPath = await pathForUri(libUri);
     var packagePath = p.dirname(libPath);
 
-    var roots = new ContextLocator().locateRoots(includedPaths: [packagePath]);
+    var roots = ContextLocator().locateRoots(includedPaths: [packagePath]);
     if (roots.length != 1) {
-      throw new StateError(
-          'Expected to find exactly one context root, got $roots');
+      throw StateError('Expected to find exactly one context root, got $roots');
     }
 
-    _analysisContext =
-        new ContextBuilder().createContext(contextRoot: roots[0]);
+    _analysisContext = ContextBuilder().createContext(contextRoot: roots[0]);
   }
 
   return _analysisContext;
@@ -44,8 +42,8 @@ Future<AnalysisContext> get analysisContext async {
 
 Future<Iterable<Uri>> findImports(Uri from, Source source) async {
   return source.unit.directives
-      .where((d) => d is UriBasedDirective)
-      .map((d) => (d as UriBasedDirective).uri.stringValue)
+      .whereType<UriBasedDirective>()
+      .map((d) => d.uri.stringValue)
       .where((uri) => !uri.startsWith('dart:'))
       .map((import) => resolveImport(import, from));
 }
@@ -60,13 +58,12 @@ Future<CompilationUnit> parseUri(Uri uri) async {
 Future<String> pathForUri(Uri uri) async {
   var fileUri = await Isolate.resolvePackageUri(uri);
   if (fileUri == null || !fileUri.isScheme('file')) {
-    throw new StateError(
-        'Expected to resolve $uri to a file URI, got $fileUri');
+    throw StateError('Expected to resolve $uri to a file URI, got $fileUri');
   }
   return p.fromUri(fileUri);
 }
 
-Future<Source> read(Uri uri) async => new Source(uri, await parseUri(uri));
+Future<Source> read(Uri uri) async => Source(uri, await parseUri(uri));
 
 Uri resolveImport(String import, Uri from) {
   if (import.startsWith('package:')) return Uri.parse(import);

--- a/example/example.dart
+++ b/example/example.dart
@@ -29,11 +29,11 @@ class Node {
 }
 
 void main() {
-  var nodeA = new Node('A', 1);
-  var nodeB = new Node('B', 2);
-  var nodeC = new Node('C', 3);
-  var nodeD = new Node('D', 4);
-  var graph = new Graph({
+  var nodeA = Node('A', 1);
+  var nodeB = Node('B', 2);
+  var nodeC = Node('C', 3);
+  var nodeD = Node('D', 4);
+  var graph = Graph({
     nodeA: [nodeB, nodeC],
     nodeB: [nodeC, nodeD],
     nodeC: [nodeB, nodeD]

--- a/lib/src/crawl_async.dart
+++ b/lib/src/crawl_async.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-final _empty = new Future<Null>.value(null);
+final _empty = Future<Null>.value(null);
 
 /// Finds and returns every node in a graph who's nodes and edges are
 /// asynchronously resolved.
@@ -30,18 +30,18 @@ final _empty = new Future<Null>.value(null);
 /// work may have already been started.
 Stream<V> crawlAsync<K, V>(Iterable<K> roots, FutureOr<V> Function(K) readNode,
     FutureOr<Iterable<K>> Function(K, V) children) {
-  final crawl = new _CrawlAsync(roots, readNode, children)..run();
+  final crawl = _CrawlAsync(roots, readNode, children)..run();
   return crawl.result.stream;
 }
 
 class _CrawlAsync<K, V> {
-  final result = new StreamController<V>();
+  final result = StreamController<V>();
 
   final FutureOr<V> Function(K) readNode;
   final FutureOr<Iterable<K>> Function(K, V) children;
   final Iterable<K> roots;
 
-  final _seen = new Set<K>();
+  final _seen = Set<K>();
 
   _CrawlAsync(this.roots, this.readNode, this.children);
 

--- a/lib/src/strongly_connected_components.dart
+++ b/lib/src/strongly_connected_components.dart
@@ -28,10 +28,10 @@ List<List<V>> stronglyConnectedComponents<K, V>(
   final result = <List<V>>[];
   final lowLinks = <K, int>{};
   final indexes = <K, int>{};
-  final onStack = new Set<K>();
+  final onStack = Set<K>();
 
   var index = 0;
-  var lastVisited = new Queue<V>();
+  var lastVisited = Queue<V>();
 
   void strongConnect(V node) {
     var nodeKey = key(node);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: graphs
-version: 0.1.2+1
+version: 0.1.3-dev
 description: Graph algorithms operation an graphs in any representation.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/graphs
 
 environment:
-  sdk: '>=2.0.0-dev.48.0 <3.0.0'
+  sdk: '>=2.0.0-dev.64.0 <3.0.0'
 
 dev_dependencies:
   test: ^0.12.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.0.0-dev.64.0 <3.0.0'
 
 dev_dependencies:
-  test: ^0.12.0
+  test: ^1.0.0
   # For examples
   analyzer: ^0.32.0
   path: ^1.1.0

--- a/test/crawl_async_test.dart
+++ b/test/crawl_async_test.dart
@@ -14,7 +14,7 @@ void main() {
   group('asyncCrawl', () {
     Future<List<String>> crawl(
         Map<String, List<String>> g, Iterable<String> roots) {
-      var graph = new AsyncGraph(g);
+      var graph = AsyncGraph(g);
       return crawlAsync(roots, graph.readNode, graph.children).toList();
     }
 
@@ -90,7 +90,7 @@ void main() {
         'a': ['b'],
       };
       var nodes = crawlAsync(['a'], (n) => n,
-          (k, n) => k == 'b' ? throw new ArgumentError() : graph[k]);
+          (k, n) => k == 'b' ? throw ArgumentError() : graph[k]);
       expect(nodes, emitsThrough(emitsError(isArgumentError)));
     });
 
@@ -98,8 +98,8 @@ void main() {
       var graph = {
         'a': ['b'],
       };
-      var nodes = crawlAsync(['a'],
-          (n) => n == 'b' ? throw new ArgumentError() : n, (k, n) => graph[k]);
+      var nodes = crawlAsync(['a'], (n) => n == 'b' ? throw ArgumentError() : n,
+          (k, n) => graph[k]);
       expect(nodes, emitsThrough(emitsError(isArgumentError)));
     });
   });

--- a/test/strongly_connected_components_test.dart
+++ b/test/strongly_connected_components_test.dart
@@ -11,7 +11,7 @@ void main() {
   group('strongly connected components', () {
     /// Run [stronglyConnectedComponents] on [g].
     List<List<String>> components(Map<String, List<String>> g) {
-      final graph = new Graph(g);
+      final graph = Graph(g);
       return stronglyConnectedComponents(
           graph.allNodes, graph.key, graph.children);
     }
@@ -53,7 +53,7 @@ void main() {
     test('includes the first passed root last in a cycle', () {
       // In cases where this is used to find a topological ordering the first
       // value in nodes should always come last.
-      var graph = new Graph({
+      var graph = Graph({
         'a': ['b'],
         'b': ['a']
       });


### PR DESCRIPTION
- `dartfmt --fix` to drop optional `new`.
- Change example to use `whereType`.
- Update minimum SDK to one that was Dart 2 semantics by default.
- Test on stable.