### PR TITLE
BREAKING: use hashCode/equals instead of keys for handling non-identity values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.2.0-dev
+
+- **BREAKING** `shortestPath`, `shortestPaths` and `stronglyConnectedComponents`
+  now have one generic parameter and have replaced the `key` parameter with
+  optional params: `{bool equals(T key1, T key2), int hashCode(T key)}`.
+  This follows the pattern used in `dart:collection` classes `HashMap` and 
+  `LinkedHashMap`. It improves the usability and performance of the case where
+  the source values are directly usable in a hash data structure.
+
 # 0.1.3+1
 
 - Fixed a bug with non-identity `key` in `shortestPath` and `shortestPaths`.
@@ -5,7 +14,7 @@
 # 0.1.3
 
 - Added `shortestPath` and `shortestPaths` functions.
-- Use `HashMap` and `HashSet` from `dart:collection` for 
+- Use `HashMap` and `HashSet` from `dart:collection` for
   `stronglyConnectedComponents`. Improves runtime performance.
 
 # 0.1.2+1

--- a/README.md
+++ b/README.md
@@ -21,24 +21,21 @@ class Graph {
   Node root;
 }
 class Node {
-  List<Node> children;
+  List<Node> edges;
   // Interesting data
 }
 ```
 
 Any representation can be adapted to the needs of the algorithm:
 
-- Some algorithms need to associate data with each node in the graph and it will
-  be keyed by some type `K` that must work as a key in a `HashMap`. If nodes
-  implement `hashCode` and `==`, or if they are known to have one instance per
-  logical node such that instance equality is sufficient, then the node can be
-  passed through directly.
-  - `(node) => node`
-  - `(node) => node.id`
-- Algorithms which need to traverse the graph take a `children` function which
+- Some algorithms need to associate data with each node in the graph. If the
+  node type `T` does not correctly or efficiently implement `hashCode` or `==`,
+  you may provide optional `equals` and/or `hashCode` functions are parameters.
+- Algorithms which need to traverse the graph take a `edges` function which
   provides the reachable nodes.
   - `(node) => graph[node]`
-  - `(node) => node.children`
+  - `(node) => node.edges`
+
 
 Graphs which are resolved asynchronously will have similar functions which
 return `FutureOr`.

--- a/benchmark/connected_components_benchmark.dart
+++ b/benchmark/connected_components_benchmark.dart
@@ -31,8 +31,8 @@ void main() {
     final watch = Stopwatch()..start();
     while (watch.elapsed < duration) {
       count++;
-      final length = stronglyConnectedComponents(
-          graph.keys, (v) => v, (e) => graph[e] ?? []).length;
+      final length =
+          stronglyConnectedComponents(graph.keys, (e) => graph[e] ?? []).length;
       assert(length == 244, '$length');
     }
 

--- a/benchmark/connected_components_benchmark.dart
+++ b/benchmark/connected_components_benchmark.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+import 'dart:math' show Random;
+
+import 'package:graphs/graphs.dart';
+
+void main() {
+  final _rnd = Random(0);
+  final size = 2000;
+  final graph = HashMap<int, List<int>>();
+
+  for (var i = 0; i < size * 3; i++) {
+    final toList = graph.putIfAbsent(_rnd.nextInt(size), () => <int>[]);
+
+    final toValue = _rnd.nextInt(size);
+    if (!toList.contains(toValue)) {
+      toList.add(toValue);
+    }
+  }
+
+  var maxCount = 0;
+  var maxIteration = 0;
+
+  final duration = const Duration(milliseconds: 100);
+
+  for (var i = 1;; i++) {
+    var count = 0;
+    final watch = Stopwatch()..start();
+    while (watch.elapsed < duration) {
+      count++;
+      final length = stronglyConnectedComponents(
+          graph.keys, (v) => v, (e) => graph[e] ?? []).length;
+      assert(length == 244, '$length');
+    }
+
+    if (count > maxCount) {
+      maxCount = count;
+      maxIteration = i;
+    }
+
+    if (maxIteration == i || (i - maxIteration) % 20 == 0) {
+      print('max iterations in ${duration.inMilliseconds}ms: $maxCount\t'
+          'after $maxIteration of $i iterations');
+    }
+  }
+}

--- a/benchmark/shortest_path_benchmark.dart
+++ b/benchmark/shortest_path_benchmark.dart
@@ -21,27 +21,34 @@ void main() {
     }
   }
 
-  var mostPerSecond = 0;
+  var maxCount = 0;
+  var maxIteration = 0;
 
   final testOutput =
       shortestPath(0, size - 1, (v) => v, (e) => graph[e] ?? []).toString();
   print(testOutput);
   assert(testOutput == '[258, 252, 819, 999]');
 
-  for (var i = 0;; i++) {
+  final duration = const Duration(milliseconds: 100);
+
+  for (var i = 1;; i++) {
     var count = 0;
     final watch = Stopwatch()..start();
-    while (watch.elapsed < const Duration(milliseconds: 100)) {
+    while (watch.elapsed < duration) {
       count++;
       final length =
           shortestPath(0, size - 1, (v) => v, (e) => graph[e] ?? []).length;
       assert(length == 4, '$length');
     }
 
-    if (count > mostPerSecond) {
-      mostPerSecond = count;
+    if (count > maxCount) {
+      maxCount = count;
+      maxIteration = i;
     }
 
-    print('max iterations in 1s: $mostPerSecond\tafter $i iterations');
+    if (maxIteration == i || (i - maxIteration) % 20 == 0) {
+      print('max iterations in ${duration.inMilliseconds}ms: $maxCount\t'
+          'after $maxIteration of $i iterations');
+    }
   }
 }

--- a/benchmark/shortest_path_benchmark.dart
+++ b/benchmark/shortest_path_benchmark.dart
@@ -25,7 +25,7 @@ void main() {
   var maxIteration = 0;
 
   final testOutput =
-      shortestPath(0, size - 1, (v) => v, (e) => graph[e] ?? []).toString();
+      shortestPath(0, size - 1, (e) => graph[e] ?? []).toString();
   print(testOutput);
   assert(testOutput == '[258, 252, 819, 999]');
 
@@ -36,8 +36,7 @@ void main() {
     final watch = Stopwatch()..start();
     while (watch.elapsed < duration) {
       count++;
-      final length =
-          shortestPath(0, size - 1, (v) => v, (e) => graph[e] ?? []).length;
+      final length = shortestPath(0, size - 1, (e) => graph[e] ?? []).length;
       assert(length == 4, '$length');
     }
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -9,6 +9,7 @@ import 'package:graphs/graphs.dart';
 /// Data is stored on the [Node] class.
 class Graph {
   final Map<Node, List<Node>> nodes;
+
   Graph(this.nodes);
 }
 
@@ -39,8 +40,8 @@ void main() {
     nodeC: [nodeB, nodeD]
   });
 
-  var components = stronglyConnectedComponents<Node, Node>(
-      graph.nodes.keys, (node) => node, (node) => graph.nodes[node]);
+  var components = stronglyConnectedComponents<Node>(
+      graph.nodes.keys, (node) => graph.nodes[node]);
 
   print(components);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: graphs
-version: 0.1.3+1
+version: 0.2.0-dev
 description: Graph algorithms operation an graphs in any representation.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/graphs

--- a/test/crawl_async_test.dart
+++ b/test/crawl_async_test.dart
@@ -15,7 +15,7 @@ void main() {
     Future<List<String>> crawl(
         Map<String, List<String>> g, Iterable<String> roots) {
       var graph = AsyncGraph(g);
-      return crawlAsync(roots, graph.readNode, graph.children).toList();
+      return crawlAsync(roots, graph.readNode, graph.edges).toList();
     }
 
     test('empty result for empty graph', () async {
@@ -65,7 +65,7 @@ void main() {
       expect(result, allOf(contains('a'), contains('b')));
     });
 
-    test('allows null children', () async {
+    test('allows null edges', () async {
       var result = await crawl({
         'a': ['b'],
         'b': null,
@@ -85,7 +85,7 @@ void main() {
       expect(result, ['a']);
     });
 
-    test('surfaces exceptions for crawling children', () {
+    test('surfaces exceptions for crawling edges', () {
       var graph = {
         'a': ['b'],
       };

--- a/test/shortest_path_test.dart
+++ b/test/shortest_path_test.dart
@@ -11,79 +11,76 @@ Matcher _throwsAssertionError(messageMatcher) =>
     throwsA(const TypeMatcher<AssertionError>()
         .having((ae) => ae.message, 'message', messageMatcher));
 
-int _xKey(X input) => input.value;
-
-T _identity<T>(T input) => input;
-
 void main() {
-  const graph = <int, List<int>>{
-    1: [2, 5],
-    2: [3],
-    3: [4, 5],
-    4: [1],
-    5: [8],
-    6: [7],
+  const graph = <String, List<String>>{
+    '1': ['2', '5'],
+    '2': ['3'],
+    '3': ['4', '5'],
+    '4': ['1'],
+    '5': ['8'],
+    '6': ['7'],
   };
 
-  List<int> getValues(int key) => graph[key] ?? [];
+  List<String> getValues(String key) => graph[key] ?? [];
 
   List<X> getXValues(X key) =>
       graph[key.value]?.map((v) => X(v))?.toList() ?? [];
 
   test('null `start` throws AssertionError', () {
-    expect(() => shortestPath(null, 1, _identity, getValues),
+    expect(() => shortestPath(null, '1', getValues),
         _throwsAssertionError('`start` cannot be null'));
-    expect(() => shortestPaths(null, _identity, getValues),
+    expect(() => shortestPaths(null, getValues),
         _throwsAssertionError('`start` cannot be null'));
   });
 
   test('null `edges` throws AssertionError', () {
-    expect(() => shortestPath(1, 1, _identity, null),
+    expect(() => shortestPath(1, 1, null),
         _throwsAssertionError('`edges` cannot be null'));
-    expect(() => shortestPaths(1, _identity, null),
+    expect(() => shortestPaths(1, null),
         _throwsAssertionError('`edges` cannot be null'));
   });
 
   test('null return value from `edges` throws', () {
-    expect(shortestPath(1, 1, _identity, (input) => null), [],
+    expect(shortestPath(1, 1, (input) => null), [],
         reason: 'self target short-circuits');
-    expect(shortestPath(1, 1, _identity, (input) => [null]), [],
+    expect(shortestPath(1, 1, (input) => [null]), [],
         reason: 'self target short-circuits');
 
-    expect(() => shortestPath(1, 2, _identity, (input) => null),
-        throwsNoSuchMethodError);
+    expect(() => shortestPath(1, 2, (input) => null), throwsNoSuchMethodError);
 
-    expect(() => shortestPaths(1, _identity, (input) => null),
-        throwsNoSuchMethodError);
+    expect(() => shortestPaths(1, (input) => null), throwsNoSuchMethodError);
 
-    expect(() => shortestPath(1, 2, _identity, (input) => [null]),
+    expect(() => shortestPath(1, 2, (input) => [null]),
         _throwsAssertionError('`edges` cannot return null values.'));
-    expect(() => shortestPaths(1, _identity, (input) => [null]),
+    expect(() => shortestPaths(1, (input) => [null]),
         _throwsAssertionError('`edges` cannot return null values.'));
   });
 
-  void _singlePathTest(int from, int to, List<int> expected) {
+  void _singlePathTest(String from, String to, List<String> expected) {
     test('$from -> $to should be $expected (mapped)', () {
       expect(
-          shortestPath<int, X>(X(from), X(to), _xKey, getXValues)
+          shortestPath<X>(X(from), X(to), getXValues,
+                  equals: xEquals, hashCode: xHashCode)
               ?.map((x) => x.value),
           expected);
     });
 
     test('$from -> $to should be $expected', () {
-      expect(shortestPath<int, int>(from, to, _identity, getValues), expected);
+      expect(shortestPath(from, to, getValues), expected);
     });
   }
 
-  void _pathsTest(int from, Map<int, List<int>> expected, List<int> nullPaths) {
+  void _pathsTest(
+      String from, Map<String, List<String>> expected, List<String> nullPaths) {
     test('paths from $from (mapped)', () {
-      final result = shortestPaths<int, X>(X(from), _xKey, getXValues)
-          .map((k, v) => MapEntry(k, v.map((x) => x.value).toList()));
+      final result = shortestPaths<X>(X(from), getXValues,
+              equals: xEquals, hashCode: xHashCode)
+          .map((k, v) => MapEntry(k.value, v.map((x) => x.value).toList()));
       expect(result, expected);
     });
 
     test('paths from $from', () {
-      final result = shortestPaths<int, int>(from, _identity, getValues);
+      final result = shortestPaths(from, getValues);
       expect(result, expected);
     });
 
@@ -96,27 +93,27 @@ void main() {
     }
   }
 
-  _pathsTest(1, {
-    5: [5],
-    3: [2, 3],
-    8: [5, 8],
-    1: [],
-    2: [2],
-    4: [2, 3, 4],
+  _pathsTest('1', {
+    '5': ['5'],
+    '3': ['2', '3'],
+    '8': ['5', '8'],
+    '1': [],
+    '2': ['2'],
+    '4': ['2', '3', '4'],
   }, [
-    6,
-    7,
+    '6',
+    '7',
   ]);
 
-  _pathsTest(6, {
-    7: [7],
-    6: [],
+  _pathsTest('6', {
+    '7': ['7'],
+    '6': [],
   }, [
-    1,
+    '1',
   ]);
-  _pathsTest(7, {7: []}, [1, 6]);
+  _pathsTest('7', {'7': []}, ['1', '6']);
 
-  _pathsTest(42, {42: []}, [1, 6]);
+  _pathsTest('42', {'42': []}, ['1', '6']);
 
-  _singlePathTest(1, null, null);
+  _singlePathTest('1', null, null);
 }

--- a/test/strongly_connected_components_test.dart
+++ b/test/strongly_connected_components_test.dart
@@ -2,18 +2,22 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:test/test.dart';
 import 'package:graphs/graphs.dart';
+import 'package:test/test.dart';
 
 import 'utils/graph.dart';
+import 'utils/utils.dart';
 
 void main() {
   group('strongly connected components', () {
     /// Run [stronglyConnectedComponents] on [g].
-    List<List<String>> components(Map<String, List<String>> g) {
+    List<List<String>> components(
+      Map<String, List<String>> g, {
+      Iterable<String> startNodes,
+    }) {
       final graph = Graph(g);
       return stronglyConnectedComponents(
-          graph.allNodes, graph.key, graph.children);
+          startNodes ?? graph.allNodes, graph.edges);
     }
 
     test('empty result for empty graph', () {
@@ -53,14 +57,12 @@ void main() {
     test('includes the first passed root last in a cycle', () {
       // In cases where this is used to find a topological ordering the first
       // value in nodes should always come last.
-      var graph = Graph({
+      var graph = {
         'a': ['b'],
         'b': ['a']
-      });
-      var resultFromA =
-          stronglyConnectedComponents(['a'], graph.key, graph.children);
-      var resultFromB =
-          stronglyConnectedComponents(['b'], graph.key, graph.children);
+      };
+      var resultFromA = components(graph, startNodes: ['a']);
+      var resultFromB = components(graph, startNodes: ['b']);
       expect(resultFromA.single.last, 'a');
       expect(resultFromB.single.last, 'b');
     });
@@ -131,7 +133,149 @@ void main() {
           ]));
     });
 
-    test('handles getting null for children', () {
+    test('handles getting null for edges', () {
+      var result = components({
+        'a': ['b'],
+        'b': null,
+      });
+      expect(result, [
+        ['b'],
+        ['a']
+      ]);
+    });
+  });
+
+  group('custom hashCode and equals', () {
+    /// Run [stronglyConnectedComponents] on [g].
+    List<List<String>> components(
+      Map<String, List<String>> g, {
+      Iterable<String> startNodes,
+    }) {
+      final graph = BadGraph(g);
+
+      startNodes ??= graph.allNodes.map((n) => n.value);
+
+      return stronglyConnectedComponents<X>(
+              startNodes.map((n) => X(n)), graph.edges,
+              equals: xEquals, hashCode: xHashCode)
+          .map((list) => list.map((x) => x.value).toList())
+          .toList();
+    }
+
+    test('empty result for empty graph', () {
+      var result = components({});
+      expect(result, isEmpty);
+    });
+
+    test('single item for single node', () {
+      var result = components({'a': []});
+      expect(result, [
+        ['a']
+      ]);
+    });
+
+    test('handles non-cycles', () {
+      var result = components({
+        'a': ['b'],
+        'b': ['c'],
+        'c': []
+      });
+      expect(result, [
+        ['c'],
+        ['b'],
+        ['a']
+      ]);
+    });
+
+    test('handles entire graph as cycle', () {
+      var result = components({
+        'a': ['b'],
+        'b': ['c'],
+        'c': ['a']
+      });
+      expect(result, [allOf(contains('a'), contains('b'), contains('c'))]);
+    });
+
+    test('includes the first passed root last in a cycle', () {
+      // In cases where this is used to find a topological ordering the first
+      // value in nodes should always come last.
+      var graph = {
+        'a': ['b'],
+        'b': ['a']
+      };
+      var resultFromA = components(graph, startNodes: ['a']);
+      var resultFromB = components(graph, startNodes: ['b']);
+      expect(resultFromA.single.last, 'a');
+      expect(resultFromB.single.last, 'b');
+    });
+
+    test('handles cycles in the middle', () {
+      var result = components({
+        'a': ['b', 'c'],
+        'b': ['c', 'd'],
+        'c': ['b', 'd'],
+        'd': [],
+      });
+      expect(result, [
+        ['d'],
+        allOf(contains('b'), contains('c')),
+        ['a'],
+      ]);
+    });
+
+    test('handles self cycles', () {
+      var result = components({
+        'a': ['b'],
+        'b': ['b'],
+      });
+      expect(result, [
+        ['b'],
+        ['a'],
+      ]);
+    });
+
+    test('valid topological ordering for disjoint subgraphs', () {
+      var result = components({
+        'a': ['b', 'c'],
+        'b': ['b1', 'b2'],
+        'c': ['c1', 'c2'],
+        'b1': [],
+        'b2': [],
+        'c1': [],
+        'c2': []
+      });
+
+      expect(
+          result,
+          containsAllInOrder([
+            ['c1'],
+            ['c'],
+            ['a']
+          ]));
+      expect(
+          result,
+          containsAllInOrder([
+            ['c2'],
+            ['c'],
+            ['a']
+          ]));
+      expect(
+          result,
+          containsAllInOrder([
+            ['b1'],
+            ['b'],
+            ['a']
+          ]));
+      expect(
+          result,
+          containsAllInOrder([
+            ['b2'],
+            ['b'],
+            ['a']
+          ]));
+    });
+
+    test('handles getting null for edges', () {
       var result = components({
         'a': ['b'],
         'b': null,

--- a/test/utils/graph.dart
+++ b/test/utils/graph.dart
@@ -3,20 +3,36 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:collection';
+
+import 'utils.dart';
 
 /// A representation of a Graph since none is specified in `lib/`.
 class Graph {
-  final Map<String, List<String>> graph;
+  final Map<String, List<String>> _graph;
 
-  Graph(this.graph);
+  Graph(this._graph);
 
-  String key(String node) => node;
-  List<String> children(String node) => graph[node];
-  Iterable<String> get allNodes => graph.keys;
+  List<String> edges(String node) => _graph[node];
+
+  Iterable<String> get allNodes => _graph.keys;
+}
+
+class BadGraph {
+  final Map<X, List<X>> _graph;
+
+  BadGraph(Map<String, List<String>> values)
+      : _graph = LinkedHashMap(equals: xEquals, hashCode: xHashCode)
+          ..addEntries(values.entries.map(
+              (e) => MapEntry(X(e.key), e?.value?.map((v) => X(v))?.toList())));
+
+  List<X> edges(X node) => _graph[node];
+
+  Iterable<X> get allNodes => _graph.keys;
 }
 
 /// A representation of a Graph where keys can asynchronously be resolved to
-/// real values or to children.
+/// real values or to edges.
 class AsyncGraph {
   final Map<String, List<String>> graph;
 
@@ -24,6 +40,6 @@ class AsyncGraph {
 
   Future<String> readNode(String node) async =>
       graph.containsKey(node) ? node : null;
-  Future<Iterable<String>> children(String key, String node) async =>
-      graph[key];
+
+  Future<Iterable<String>> edges(String key, String node) async => graph[key];
 }

--- a/test/utils/utils.dart
+++ b/test/utils/utils.dart
@@ -2,8 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+bool xEquals(X a, X b) => a?.value == b?.value;
+
+int xHashCode(X a) => a.value.hashCode;
+
 class X {
-  final int value;
+  final String value;
 
   X(this.value);
 


### PR DESCRIPTION
@natebosch – I think we can take a page from the `HashMap`, `LinkedHashMap` constructors here.

The idea of having a `key` object is just a proxy for supporting custom equals/hashCode on an object.

Thoughts? (If this seems reasonable, we can roll the other functions to do something similar)

CC @jakemac53 as FYI