### PR TITLE
Clarify that edges may have overlapping calls

### DIFF
--- a/example/crawl_async_example.dart
+++ b/example/crawl_async_example.dart
@@ -11,12 +11,18 @@ import 'package:analyzer/dart/analysis/context_locator.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:graphs/graphs.dart';
 import 'package:path/path.dart' as p;
+import 'package:pool/pool.dart';
+
+/// Limits calls to [findImports].
+final _pool = Pool(10);
 
 /// Print a transitive set of imported URIs where libraries are read
 /// asynchronously.
 Future<Null> main() async {
-  var allImports = await crawlAsync(
-          [Uri.parse('package:graphs/graphs.dart')], read, findImports)
+  var allImports = await crawlAsync<Uri, Source>(
+          [Uri.parse('package:graphs/graphs.dart')],
+          read,
+          (from, source) => _pool.withResource(() => findImports(from, source)))
       .toList();
   print(allImports.map((s) => s.uri).toList());
 }

--- a/example/crawl_async_example.dart
+++ b/example/crawl_async_example.dart
@@ -13,12 +13,11 @@ import 'package:graphs/graphs.dart';
 import 'package:path/path.dart' as p;
 import 'package:pool/pool.dart';
 
-/// Limits calls to [findImports].
-final _pool = Pool(10);
-
 /// Print a transitive set of imported URIs where libraries are read
 /// asynchronously.
 Future<Null> main() async {
+  // Limits calls to [findImports].
+  var _pool = Pool(10);
   var allImports = await crawlAsync<Uri, Source>(
           [Uri.parse('package:graphs/graphs.dart')],
           read,

--- a/lib/src/crawl_async.dart
+++ b/lib/src/crawl_async.dart
@@ -29,6 +29,10 @@ final _empty = Future<Null>.value(null);
 /// If either [readNode] or [edges] throws the error will be forwarded
 /// through the result stream and no further nodes will be crawled, though some
 /// work may have already been started.
+///
+/// Crawling is eager, calls to [edges] may overlap with other calls that have
+/// not completed. If the [edges] callback needs to be limited or throttled that
+/// must be done by wrapping it before calling [crawlAsync].
 Stream<V> crawlAsync<K, V>(Iterable<K> roots, FutureOr<V> Function(K) readNode,
     FutureOr<Iterable<K>> Function(K, V) edges) {
   final crawl = _CrawlAsync(roots, readNode, edges)..run();

--- a/lib/src/crawl_async.dart
+++ b/lib/src/crawl_async.dart
@@ -30,9 +30,9 @@ final _empty = Future<Null>.value(null);
 /// through the result stream and no further nodes will be crawled, though some
 /// work may have already been started.
 ///
-/// Crawling is eager, calls to [edges] may overlap with other calls that have
-/// not completed. If the [edges] callback needs to be limited or throttled that
-/// must be done by wrapping it before calling [crawlAsync].
+/// Crawling is eager, so calls to [edges] may overlap with other calls that
+/// have not completed. If the [edges] callback needs to be limited or throttled
+/// that must be done by wrapping it before calling [crawlAsync].
 Stream<V> crawlAsync<K, V>(Iterable<K> roots, FutureOr<V> Function(K) readNode,
     FutureOr<Iterable<K>> Function(K, V) edges) {
   final crawl = _CrawlAsync(roots, readNode, edges)..run();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,3 +14,4 @@ dev_dependencies:
   # For examples
   analyzer: ^0.34.0
   path: ^1.1.0
+  pool: ^1.3.0


### PR DESCRIPTION
Closes #39

Add a note in the doc comment that the edges callback must be throttled
independently, it won't be throttled by `crawlAsync`.

Update the example usage to show how the `pool` package can be used to
implement limiting.