### PR TITLE
Fix strict-inference violations

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,6 +2,8 @@ include: package:pedantic/analysis_options.yaml
 analyzer:
   strong-mode:
     implicit-casts: false
+  language:
+    strict-inference: true
   errors:
     unused_element: error
     unused_import: error

--- a/lib/src/shortest_path.dart
+++ b/lib/src/shortest_path.dart
@@ -134,4 +134,4 @@ Map<T, List<T>> _shortestPaths<T>(
   return distances;
 }
 
-bool _defaultEquals(a, b) => a == b;
+bool _defaultEquals(Object a, Object b) => a == b;

--- a/lib/src/strongly_connected_components.dart
+++ b/lib/src/strongly_connected_components.dart
@@ -78,4 +78,4 @@ List<List<T>> stronglyConnectedComponents<T>(
   return result;
 }
 
-bool _defaultEquals(a, b) => a == b;
+bool _defaultEquals(Object a, Object b) => a == b;

--- a/test/shortest_path_test.dart
+++ b/test/shortest_path_test.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 
 import 'utils/utils.dart';
 
-Matcher _throwsAssertionError(messageMatcher) =>
+Matcher _throwsAssertionError(dynamic messageMatcher) =>
     throwsA(const TypeMatcher<AssertionError>()
         .having((ae) => ae.message, 'message', messageMatcher));
 
@@ -44,9 +44,9 @@ void main() {
   });
 
   test('null return value from `edges` throws', () {
-    expect(shortestPath(1, 1, (input) => null), [],
+    expect(shortestPath(1, 1, (input) => null), <dynamic>[],
         reason: 'self target short-circuits');
-    expect(shortestPath(1, 1, (input) => [null]), [],
+    expect(shortestPath(1, 1, (input) => [null]), <dynamic>[],
         reason: 'self target short-circuits');
 
     expect(() => shortestPath(1, 2, (input) => null), throwsNoSuchMethodError);


### PR DESCRIPTION
Add type annotations to all arguments and generics where they can't be
inferred and fall back to `dynamic`.