### PR TITLE
Fix newly enforced package:pedantic lints

### DIFF
--- a/lib/src/shortest_path.dart
+++ b/lib/src/shortest_path.dart
@@ -28,8 +28,8 @@ List<T> shortestPath<T>(
   T start,
   T target,
   Iterable<T> Function(T) edges, {
-  bool equals(T key1, T key2),
-  int hashCode(T key),
+  bool Function(T, T) equals,
+  int Function(T) hashCode,
 }) =>
     _shortestPaths<T>(
       start,
@@ -61,8 +61,8 @@ List<T> shortestPath<T>(
 Map<T, List<T>> shortestPaths<T>(
   T start,
   Iterable<T> Function(T) edges, {
-  bool equals(T key1, T key2),
-  int hashCode(T key),
+  bool Function(T, T) equals,
+  int Function(T) hashCode,
 }) =>
     _shortestPaths<T>(
       start,
@@ -75,8 +75,8 @@ Map<T, List<T>> _shortestPaths<T>(
   T start,
   Iterable<T> Function(T) edges, {
   T target,
-  bool equals(T key1, T key2),
-  int hashCode(T key),
+  bool Function(T, T) equals,
+  int Function(T) hashCode,
 }) {
   assert(start != null, '`start` cannot be null');
   assert(edges != null, '`edges` cannot be null');

--- a/lib/src/strongly_connected_components.dart
+++ b/lib/src/strongly_connected_components.dart
@@ -32,8 +32,8 @@ import 'dart:math' show min;
 List<List<T>> stronglyConnectedComponents<T>(
   Iterable<T> nodes,
   Iterable<T> Function(T) edges, {
-  bool equals(T key1, T key2),
-  int hashCode(T key),
+  bool Function(T, T) equals,
+  int Function(T) hashCode,
 }) {
   final result = <List<T>>[];
   final lowLinks = HashMap<T, int>(equals: equals, hashCode: hashCode);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,6 @@
 name: graphs
 version: 0.2.1-dev
 description: Graph algorithms that operate on graphs in any representation
-author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/graphs
 
 environment:


### PR DESCRIPTION
- use_function_type_syntax_for_parameters

Drop unused author field from pubspec.