### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/test/utils/graph.dart
+++ b/test/utils/graph.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:collection';
 
 import 'utils.dart';


### PR DESCRIPTION
As of Dart 2.1, Future and Stream are exported from dart:core