### PR TITLE
Remove diagnostic upgrades to errors

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,18 +4,9 @@ analyzer:
     implicit-casts: false
   language:
     strict-inference: true
-  errors:
-    unused_element: error
-    unused_import: error
-    unused_local_variable: error
-    dead_code: error
 linter:
   rules:
-    - annotate_overrides
     - avoid_function_literals_in_foreach_calls
-    - avoid_init_to_null
-    - avoid_null_checks_in_equality_operators
-    - avoid_relative_lib_imports
     - avoid_returning_null
     - avoid_unused_constructor_parameters
     - await_only_futures
@@ -25,43 +16,27 @@ linter:
     - constant_identifier_names
     - control_flow_in_finally
     - directives_ordering
-    - empty_catches
-    - empty_constructor_bodies
     - empty_statements
     - hash_and_equals
     - implementation_imports
     - invariant_booleans
     - iterable_contains_unrelated_type
-    - library_names
-    - library_prefixes
     - list_remove_unrelated_type
     - no_adjacent_strings_in_list
     - non_constant_identifier_names
-    - omit_local_variable_types
     - only_throw_errors
     - overridden_fields
     - package_api_docs
     - package_names
     - package_prefixed_library_names
-    - prefer_adjacent_string_concatenation
-    - prefer_collection_literals
-    - prefer_conditional_assignment
     - prefer_const_constructors
-    - prefer_final_fields
-    - prefer_generic_function_type_aliases
     - prefer_initializing_formals
     - prefer_interpolation_to_compose_strings
-    - prefer_single_quotes
     - prefer_typing_uninitialized_variables
-    - slash_for_doc_comments
     - test_types_in_equals
     - throw_in_finally
-    - type_init_formals
     - unnecessary_brace_in_string_interps
-    - unnecessary_const
     - unnecessary_getters_setters
     - unnecessary_lambdas
-    - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_statements
-    - unnecessary_this


### PR DESCRIPTION
We run the analyzer with --fatal-infos so it is not necessary to upgrade
warnings or hints to errors.

Remove the lint rules that are duplicative with `pedantic`.