### PR TITLE
Simplify shortestPath, and optimize it a bit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.8.1, dev]
+        sdk: [2.9.0, dev]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.3.0, dev]
+        sdk: [2.8.0, dev]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.8.0, dev]
+        sdk: [2.8.1, dev]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - **Breaking**: Paths from `shortestPath[s]` are now returned as iterables to
   reduce memory consumption of the algorithm to O(n).
-- Require Dart SDK `>=2.8.1 <3.0.0`.
+- Require Dart SDK `>=2.9.0 <3.0.0`.
 
 # 0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.0-dev
+
+- **Breaking**: Paths from `shortestPath[s]` are now returned as iterables to
+  reduce memory consumption of the algorithm to O(n).
+
 # 0.2.1
 
 - Require Dart SDK `>=2.2.0 <3.0.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - **Breaking**: Paths from `shortestPath[s]` are now returned as iterables to
   reduce memory consumption of the algorithm to O(n).
-- Require Dart SDK `>=2.8.0 <3.0.0`.
+- Require Dart SDK `>=2.8.1 <3.0.0`.
 
 # 0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **Breaking**: Paths from `shortestPath[s]` are now returned as iterables to
   reduce memory consumption of the algorithm to O(n).
+- Require Dart SDK `>=2.8.0 <3.0.0`.
 
 # 0.2.1
 

--- a/benchmark/shortest_path_benchmark.dart
+++ b/benchmark/shortest_path_benchmark.dart
@@ -27,16 +27,19 @@ void main() {
   final testOutput =
       shortestPath(0, size - 1, (e) => graph[e] ?? []).toString();
   print(testOutput);
-  assert(testOutput == '[258, 252, 819, 999]');
+  assert(testOutput == '(258, 252, 819, 999)', testOutput);
 
   final watch = Stopwatch();
   for (var i = 1;; i++) {
     watch
       ..reset()
       ..start();
-    final length = shortestPath(0, size - 1, (e) => graph[e] ?? []).length;
+    final result = shortestPath(0, size - 1, (e) => graph[e] ?? []);
+    final length = result.length;
+    final first = result.first;
     watch.stop();
     assert(length == 4, '$length');
+    assert(first == 258, '$first');
 
     if (minTicks == null || watch.elapsedTicks < minTicks) {
       minTicks = watch.elapsedTicks;

--- a/benchmark/shortest_path_worst_case_benchmark.dart
+++ b/benchmark/shortest_path_worst_case_benchmark.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+
+import 'package:graphs/graphs.dart';
+
+void main() {
+  final size = 1000;
+  final graph = HashMap<int, List<int>>();
+
+  // We create a graph where every subsequent node has an edge to every other
+  // node before it as well as the next node. This triggers worst case behavior
+  // in many algorithms as it requires visiting all nodes and edges before
+  // finding a solution, and there are a maximum number of edges.
+  for (var i = 0; i < size; i++) {
+    final toList = graph.putIfAbsent(i, () => <int>[]);
+    for (var t = 0; t < i + 2 && i < size; t++) {
+      if (i == t) continue;
+      toList.add(t);
+    }
+  }
+
+  int minTicks;
+  var maxIteration = 0;
+
+  final testOutput =
+      shortestPath(0, size - 1, (e) => graph[e] ?? []).toString();
+  print(testOutput);
+  assert(testOutput == '[0, 999]');
+
+  final watch = Stopwatch();
+  for (var i = 1;; i++) {
+    watch
+      ..reset()
+      ..start();
+    final length = shortestPath(0, size - 1, (e) => graph[e] ?? []).length;
+    watch.stop();
+    assert(length == 4, '$length');
+
+    if (minTicks == null || watch.elapsedTicks < minTicks) {
+      minTicks = watch.elapsedTicks;
+      maxIteration = i;
+    }
+
+    if (maxIteration == i || (i - maxIteration) % 100000 == 0) {
+      print('min ticks for one run: $minTicks\t'
+          'after $maxIteration of $i iterations');
+    }
+  }
+}

--- a/benchmark/shortest_path_worst_case_benchmark.dart
+++ b/benchmark/shortest_path_worst_case_benchmark.dart
@@ -41,7 +41,7 @@ void main() {
     final first = result.first;
     watch.stop();
     assert(length == 999, '$length');
-    assert(first == 1, 0);
+    assert(first == 1, '$first');
 
     if (minTicks == null || watch.elapsedTicks < minTicks) {
       minTicks = watch.elapsedTicks;

--- a/benchmark/shortest_path_worst_case_benchmark.dart
+++ b/benchmark/shortest_path_worst_case_benchmark.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/benchmark/shortest_path_worst_case_benchmark.dart
+++ b/benchmark/shortest_path_worst_case_benchmark.dart
@@ -28,16 +28,20 @@ void main() {
   final testOutput =
       shortestPath(0, size - 1, (e) => graph[e] ?? []).toString();
   print(testOutput);
-  assert(testOutput == '[0, 999]');
+  assert(testOutput == Iterable.generate(size - 1, (i) => i + 1).toString(),
+      '$testOutput');
 
   final watch = Stopwatch();
   for (var i = 1;; i++) {
     watch
       ..reset()
       ..start();
-    final length = shortestPath(0, size - 1, (e) => graph[e] ?? []).length;
+    final result = shortestPath(0, size - 1, (e) => graph[e] ?? []);
+    final length = result.length;
+    final first = result.first;
     watch.stop();
-    assert(length == 4, '$length');
+    assert(length == 999, '$length');
+    assert(first == 1, 0);
 
     if (minTicks == null || watch.elapsedTicks < minTicks) {
       minTicks = watch.elapsedTicks;

--- a/lib/src/shortest_path.dart
+++ b/lib/src/shortest_path.dart
@@ -100,7 +100,7 @@ Map<T, Iterable<T>> _shortestPaths<T>(
       final existingPath = distances[edge];
 
       if (existingPath == null) {
-        distances[edge] = currentPath.followedBy(List<T>.filled(1, edge));
+        distances[edge] = _Tail(currentPath, edge);
         if (equals(edge, target)) {
           return distances;
         }
@@ -113,3 +113,36 @@ Map<T, Iterable<T>> _shortestPaths<T>(
 }
 
 bool _defaultEquals(Object a, Object b) => a == b;
+
+/// Efficient iterable that allows us to share the shared parts of the path
+/// up to this point (the [head]) with all other paths leading from it, but
+/// still iterate in the correct order.
+class _Tail<T> extends Iterable<T> {
+  final Iterable<T> head;
+  final T tail;
+
+  _Tail(this.head, this.tail);
+
+  @override
+  Iterator<T> get iterator => _TailIterator<T>(head.iterator, tail);
+}
+
+class _TailIterator<T> implements Iterator<T> {
+  final Iterator<T> head;
+  final T tail;
+  bool inHead = true;
+
+  _TailIterator(this.head, this.tail);
+
+  @override
+  T get current => inHead ? head.current : tail;
+
+  @override
+  bool moveNext() {
+    if (inHead) {
+      inHead = head.moveNext();
+      return true;
+    }
+    return false;
+  }
+}

--- a/lib/src/shortest_path.dart
+++ b/lib/src/shortest_path.dart
@@ -82,7 +82,7 @@ Map<T, Iterable<T>> _shortestPaths<T>(
   assert(edges != null, '`edges` cannot be null');
 
   final distances = HashMap<T, _Tail<T>>(equals: equals, hashCode: hashCode);
-  distances[start] = _Tail<T>(start);
+  distances[start] = _Tail<T>();
 
   equals ??= _defaultEquals;
   if (equals(start, target)) {
@@ -124,13 +124,14 @@ bool _defaultEquals(Object a, Object b) => a == b;
 /// iterator in order to avoid stack overflows for large paths. This copy is
 /// cached for subsequent calls.
 class _Tail<T> extends Iterable<T> {
-  final T tail;
+  final T /*?*/ tail;
   final _Tail<T> /*?*/ head;
   @override
   final int length;
-  _Tail(this.tail)
-      : head = null,
-        length = 1;
+  _Tail()
+      : tail = null,
+        head = null,
+        length = 0;
   _Tail._(this.tail, this.head, this.length);
   _Tail<T> append(T value) => _Tail._(value, this, length + 1);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Graph algorithms that operate on graphs in any representation
 homepage: https://github.com/dart-lang/graphs
 
 environment:
-  sdk: '>=2.8.1 <3.0.0'
+  sdk: '>=2.9.0 <3.0.0'
 
 dev_dependencies:
   pedantic: ^1.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Graph algorithms that operate on graphs in any representation
 homepage: https://github.com/dart-lang/graphs
 
 environment:
-  sdk: '>=2.8.0 <3.0.0'
+  sdk: '>=2.8.1 <3.0.0'
 
 dev_dependencies:
   pedantic: ^1.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Graph algorithms that operate on graphs in any representation
 homepage: https://github.com/dart-lang/graphs
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.8.0 <3.0.0'
 
 dev_dependencies:
   pedantic: ^1.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: graphs
-version: 0.2.1-dev
+version: 1.0.0-dev
 description: Graph algorithms that operate on graphs in any representation
 homepage: https://github.com/dart-lang/graphs
 

--- a/test/shortest_path_test.dart
+++ b/test/shortest_path_test.dart
@@ -127,7 +127,7 @@ void main() {
     final size = 1000;
     final graph = HashMap<int, List<int>>();
 
-    List<int> resultForGraph() =>
+    Iterable<int> resultForGraph() =>
         shortestPath<int>(0, size - 1, (e) => graph[e] ?? const []);
 
     void addRandomEdge() {
@@ -139,7 +139,7 @@ void main() {
       }
     }
 
-    List<int> result;
+    Iterable<int> result;
 
     // Add edges until there is a shortest path between `0` and `size - 1`
     do {


### PR DESCRIPTION
Updates all paths to be `Iterable<T>` - this allows us to not have to copy lists whenever we extend a path. This should reduce memory consumption to O(nodes), each entry in `distances` is only a list with a single item and a pointer to another iterable instead of a copy of the entire path. This also reduces the runtime complexity to O(edges + nodes), assuming an efficient hash map (including good equality/hashCode impls for your objects).

The returned `Iterable`s do efficiently implement `length`, but a consequence of the implementation is that iterating any path for the first time is O(n) in both time and space. This includes even accessing the `first` element. A list is lazily created and populated for efficient iteration (and to avoid stack overflows).

I also simplified the logic a lot - because there is no weighting to edges and we are doing a BFS traversal we can immediately return if we find the target node. We also can immediately skip any edge that already exists in `distances` as soon as we see it.

This also eagerly avoids adding already seen nodes to `toVisit` instead of adding them to the queue and then skipping them later on. No node will ever be added to the queue more than once now.

A new worst case benchmark has also been added.