### PR TITLE
Add a `secondarySort` parameter to `topologicalSort`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 2.1.1-dev
+# 2.2.0
+
+* Add a `secondarySort` parameter to the `topologicalSort()` function which
+  applies an additional lexical sort where that doesn't break the topological
+  sort.
 
 # 2.1.0
 

--- a/lib/src/topological_sort.dart
+++ b/lib/src/topological_sort.dart
@@ -32,6 +32,9 @@ import 'cycle_exception.dart';
 /// ordering. Note that even with a secondary sort, the result is _still_ not
 /// guaranteed to be unique or stable across releases of this package.
 ///
+/// Note: this requires that [nodes] and each iterable returned by [edges]
+/// contain no duplicate entries.
+///
 /// Throws a [CycleException<T>] if the graph is cyclical.
 List<T> topologicalSort<T>(Iterable<T> nodes, Iterable<T> Function(T) edges,
     {bool Function(T, T)? equals,
@@ -106,7 +109,7 @@ List<T> _topologicalSortWithSecondary<T>(
   }
 
   if (result.length < nodes.length) {
-    // This algoirthm doesn't automatically produce a cycle list as a side
+    // This algorithm doesn't automatically produce a cycle list as a side
     // effect of sorting, so to throw the appropriate [CycleException] we just
     // call the normal [topologicalSort] with a view of this graph that only
     // includes nodes that still have edges.
@@ -116,7 +119,7 @@ List<T> _topologicalSortWithSecondary<T>(
     }
 
     topologicalSort<T>(
-        nodes.where(nodeIsInCycle), (node) => edges(node).where(nodeIsInCycle),
+        nodes.where(nodeIsInCycle), edges,
         equals: equals, hashCode: hashCode);
     assert(false, 'topologicalSort() should throw if the graph has a cycle');
   }

--- a/lib/src/topological_sort.dart
+++ b/lib/src/topological_sort.dart
@@ -4,7 +4,7 @@
 
 import 'dart:collection';
 
-import 'package:collection/collection.dart';
+import 'package:collection/collection.dart' hide stronglyConnectedComponents;
 
 import 'cycle_exception.dart';
 
@@ -27,9 +27,21 @@ import 'cycle_exception.dart';
 /// If you supply one of [equals] or [hashCode], you should generally also to
 /// supply the other.
 ///
+/// If you supply [secondarySort], the resulting list will be sorted by that
+/// comparison function as much as possible without violating the topological
+/// ordering. Note that even with a secondary sort, the result is _still_ not
+/// guaranteed to be unique or stable across releases of this package.
+///
 /// Throws a [CycleException<T>] if the graph is cyclical.
 List<T> topologicalSort<T>(Iterable<T> nodes, Iterable<T> Function(T) edges,
-    {bool Function(T, T)? equals, int Function(T)? hashCode}) {
+    {bool Function(T, T)? equals,
+    int Function(T)? hashCode,
+    Comparator<T>? secondarySort}) {
+  if (secondarySort != null) {
+    return _topologicalSortWithSecondary(
+        [...nodes], edges, secondarySort, equals, hashCode);
+  }
+
   // https://en.wikipedia.org/wiki/Topological_sorting#Depth-first_search
   var result = QueueList<T>();
   var permanentMark = HashSet<T>(equals: equals, hashCode: hashCode);
@@ -52,5 +64,62 @@ List<T> topologicalSort<T>(Iterable<T> nodes, Iterable<T> Function(T) edges,
   for (var node in nodes) {
     visit(node);
   }
+  return result;
+}
+
+/// An implementation of [topologicalSort] with a secondary comparison function.
+List<T> _topologicalSortWithSecondary<T>(
+    List<T> nodes,
+    Iterable<T> Function(T) edges,
+    Comparator<T> comparator,
+    bool Function(T, T)? equals,
+    int Function(T)? hashCode) {
+  // https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm,
+  // modified to sort the nodes to traverse. Also documented in
+  // https://www.algotree.org/algorithms/tree_graph_traversal/lexical_topological_sort_c++/
+
+  // For each node, the number of incoming edges it has that we haven't yet
+  // traversed.
+  var incomingEdges = HashMap<T, int>(equals: equals, hashCode: hashCode);
+  for (var node in nodes) {
+    for (var child in edges(node)) {
+      incomingEdges[child] = (incomingEdges[child] ?? 0) + 1;
+    }
+  }
+
+  // A priority queue of nodes that have no remaining incoming edges.
+  var nodesToTraverse = PriorityQueue<T>(comparator);
+  for (var node in nodes) {
+    if (!incomingEdges.containsKey(node)) nodesToTraverse.add(node);
+  }
+
+  var result = <T>[];
+  while (nodesToTraverse.isNotEmpty) {
+    var node = nodesToTraverse.removeFirst();
+    result.add(node);
+    for (var child in edges(node)) {
+      var remainingEdges = incomingEdges[child]!;
+      remainingEdges--;
+      incomingEdges[child] = remainingEdges;
+      if (remainingEdges == 0) nodesToTraverse.add(child);
+    }
+  }
+
+  if (result.length < nodes.length) {
+    // This algoirthm doesn't automatically produce a cycle list as a side
+    // effect of sorting, so to throw the appropriate [CycleException] we just
+    // call the normal [topologicalSort] with a view of this graph that only
+    // includes nodes that still have edges.
+    bool nodeIsInCycle(T node) {
+      var edges = incomingEdges[node];
+      return edges != null && edges > 0;
+    }
+
+    topologicalSort<T>(
+        nodes.where(nodeIsInCycle), (node) => edges(node).where(nodeIsInCycle),
+        equals: equals, hashCode: hashCode);
+    assert(false, 'topologicalSort() should throw if the graph has a cycle');
+  }
+
   return result;
 }

--- a/lib/src/topological_sort.dart
+++ b/lib/src/topological_sort.dart
@@ -118,8 +118,7 @@ List<T> _topologicalSortWithSecondary<T>(
       return edges != null && edges > 0;
     }
 
-    topologicalSort<T>(
-        nodes.where(nodeIsInCycle), edges,
+    topologicalSort<T>(nodes.where(nodeIsInCycle), edges,
         equals: equals, hashCode: hashCode);
     assert(false, 'topologicalSort() should throw if the graph has a cycle');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: graphs
-version: 2.1.1-dev
+version: 2.2.0
 description: Graph algorithms that operate on graphs in any representation
 repository: https://github.com/dart-lang/graphs
 

--- a/test/topological_sort_test.dart
+++ b/test/topological_sort_test.dart
@@ -10,119 +10,299 @@ import 'package:test/test.dart';
 import 'utils/utils.dart';
 
 void main() {
-  group('sorts a graph', () {
-    test('with no nodes', () {
-      expect(_topologicalSort({}), isEmpty);
+  group('without secondarySort', () {
+    group('topologically sorts a graph', () {
+      test('with no nodes', () {
+        expect(_topologicalSort({}), isEmpty);
+      });
+
+      test('with only one node', () {
+        expect(_topologicalSort({1: []}), equals([1]));
+      });
+
+      test('with no edges', () {
+        expect(_topologicalSort({1: [], 2: [], 3: [], 4: []}),
+            unorderedEquals([1, 2, 3, 4]));
+      });
+
+      test('with single edges', () {
+        expect(
+            _topologicalSort({
+              1: [2],
+              2: [3],
+              3: [4],
+              4: []
+            }),
+            equals([1, 2, 3, 4]));
+      });
+
+      test('with many edges from one node', () {
+        var result = _topologicalSort({
+          1: [2, 3, 4],
+          2: [],
+          3: [],
+          4: []
+        });
+        expect(result.indexOf(1), lessThan(result.indexOf(2)));
+        expect(result.indexOf(1), lessThan(result.indexOf(3)));
+        expect(result.indexOf(1), lessThan(result.indexOf(4)));
+      });
+
+      test('with transitive edges', () {
+        var result = _topologicalSort({
+          1: [2, 4],
+          2: [],
+          3: [],
+          4: [3]
+        });
+        expect(result.indexOf(1), lessThan(result.indexOf(2)));
+        expect(result.indexOf(1), lessThan(result.indexOf(3)));
+        expect(result.indexOf(1), lessThan(result.indexOf(4)));
+        expect(result.indexOf(4), lessThan(result.indexOf(3)));
+      });
+
+      test('with diamond edges', () {
+        var result = _topologicalSort({
+          1: [2, 3],
+          2: [4],
+          3: [4],
+          4: []
+        });
+        expect(result.indexOf(1), lessThan(result.indexOf(2)));
+        expect(result.indexOf(1), lessThan(result.indexOf(3)));
+        expect(result.indexOf(1), lessThan(result.indexOf(4)));
+        expect(result.indexOf(2), lessThan(result.indexOf(4)));
+        expect(result.indexOf(3), lessThan(result.indexOf(4)));
+      });
     });
 
-    test('with only one node', () {
-      expect(_topologicalSort({1: []}), equals([1]));
-    });
-
-    test('with no edges', () {
-      expect(_topologicalSort({1: [], 2: [], 3: [], 4: []}),
-          unorderedEquals([1, 2, 3, 4]));
-    });
-
-    test('with single edges', () {
+    test('respects custom equality and hash functions', () {
       expect(
-          _topologicalSort({
+          _topologicalSort<int>({
+            0: [2],
+            3: [4],
+            5: [6],
+            7: []
+          },
+              equals: (i, j) => (i ~/ 2) == (j ~/ 2),
+              hashCode: (i) => (i ~/ 2).hashCode),
+          equals([
+            0,
+            anyOf([2, 3]),
+            anyOf([4, 5]),
+            anyOf([6, 7])
+          ]));
+    });
+
+    group('throws a CycleException for a graph with', () {
+      test('a one-node cycle', () {
+        expect(
+            () => _topologicalSort({
+                  1: [1]
+                }),
+            throwsCycleException([1]));
+      });
+
+      test('a multi-node cycle', () {
+        expect(
+            () => _topologicalSort({
+                  1: [2],
+                  2: [3],
+                  3: [4],
+                  4: [1]
+                }),
+            throwsCycleException([1, 2, 3, 4]));
+      });
+    });
+  });
+
+  group('with secondarySort', () {
+    group('topologically sorts a graph', () {
+      test('with no nodes', () {
+        expect(_topologicalSort({}, secondarySort: true), isEmpty);
+      });
+
+      test('with only one node', () {
+        expect(_topologicalSort({1: []}, secondarySort: true), equals([1]));
+      });
+
+      test('with no edges', () {
+        expect(
+            _topologicalSort({1: [], 2: [], 3: [], 4: []}, secondarySort: true),
+            unorderedEquals([1, 2, 3, 4]));
+      });
+
+      test('with single edges', () {
+        expect(
+            _topologicalSort({
+              1: [2],
+              2: [3],
+              3: [4],
+              4: []
+            }, secondarySort: true),
+            equals([1, 2, 3, 4]));
+      });
+
+      test('with many edges from one node', () {
+        var result = _topologicalSort({
+          1: [2, 3, 4],
+          2: [],
+          3: [],
+          4: []
+        }, secondarySort: true);
+        expect(result.indexOf(1), lessThan(result.indexOf(2)));
+        expect(result.indexOf(1), lessThan(result.indexOf(3)));
+        expect(result.indexOf(1), lessThan(result.indexOf(4)));
+      });
+
+      test('with transitive edges', () {
+        var result = _topologicalSort({
+          1: [2, 4],
+          2: [],
+          3: [],
+          4: [3]
+        }, secondarySort: true);
+        expect(result.indexOf(1), lessThan(result.indexOf(2)));
+        expect(result.indexOf(1), lessThan(result.indexOf(3)));
+        expect(result.indexOf(1), lessThan(result.indexOf(4)));
+        expect(result.indexOf(4), lessThan(result.indexOf(3)));
+      });
+
+      test('with diamond edges', () {
+        var result = _topologicalSort({
+          1: [2, 3],
+          2: [4],
+          3: [4],
+          4: []
+        }, secondarySort: true);
+        expect(result.indexOf(1), lessThan(result.indexOf(2)));
+        expect(result.indexOf(1), lessThan(result.indexOf(3)));
+        expect(result.indexOf(1), lessThan(result.indexOf(4)));
+        expect(result.indexOf(2), lessThan(result.indexOf(4)));
+        expect(result.indexOf(3), lessThan(result.indexOf(4)));
+      });
+    });
+
+    group('lexically sorts a graph where possible', () {
+      test('with no edges', () {
+        var result =
+            _topologicalSort({4: [], 3: [], 1: [], 2: []}, secondarySort: true);
+        expect(result, equals([1, 2, 3, 4]));
+      });
+
+      test('with one non-lexical edge', () {
+        var result = _topologicalSort({
+          4: [],
+          3: [1],
+          1: [],
+          2: []
+        }, secondarySort: true);
+        expect(
+            result,
+            equals(anyOf([
+              [2, 3, 1, 4],
+              [3, 1, 2, 4]
+            ])));
+      });
+
+      test('with a non-lexical topolgical order', () {
+        var result = _topologicalSort({
+          4: [3],
+          3: [2],
+          2: [1],
+          1: []
+        }, secondarySort: true);
+        expect(result, equals([4, 3, 2, 1]));
+      });
+
+      group('with multiple layers', () {
+        test('in lexical order', () {
+          var result = _topologicalSort({
             1: [2],
             2: [3],
+            3: [],
+            4: [5],
+            5: [6],
+            6: []
+          }, secondarySort: true);
+          expect(result, equals([1, 2, 3, 4, 5, 6]));
+        });
+
+        test('in non-lexical order', () {
+          var result = _topologicalSort({
+            1: [3],
+            3: [5],
+            4: [2],
+            2: [6],
+            5: [],
+            6: []
+          }, secondarySort: true);
+          expect(
+              result,
+              anyOf([
+                equals([1, 3, 4, 2, 5, 6]),
+                equals([1, 4, 2, 3, 5, 6])
+              ]));
+        });
+      });
+    });
+
+    test('respects custom equality and hash functions', () {
+      expect(
+          _topologicalSort<int>({
+            0: [2],
             3: [4],
-            4: []
-          }),
-          equals([1, 2, 3, 4]));
+            5: [6],
+            7: []
+          },
+              equals: (i, j) => (i ~/ 2) == (j ~/ 2),
+              hashCode: (i) => (i ~/ 2).hashCode,
+              secondarySort: true),
+          equals([
+            0,
+            anyOf([2, 3]),
+            anyOf([4, 5]),
+            anyOf([6, 7])
+          ]));
     });
 
-    test('with many edges from one node', () {
-      var result = _topologicalSort({
-        1: [2, 3, 4],
-        2: [],
-        3: [],
-        4: []
+    group('throws a CycleException for a graph with', () {
+      test('a one-node cycle', () {
+        expect(
+            () => _topologicalSort({
+                  1: [1]
+                }, secondarySort: true),
+            throwsCycleException([1]));
       });
-      expect(result.indexOf(1), lessThan(result.indexOf(2)));
-      expect(result.indexOf(1), lessThan(result.indexOf(3)));
-      expect(result.indexOf(1), lessThan(result.indexOf(4)));
-    });
 
-    test('with transitive edges', () {
-      var result = _topologicalSort({
-        1: [2, 4],
-        2: [],
-        3: [],
-        4: [3]
+      test('a multi-node cycle', () {
+        expect(
+            () => _topologicalSort({
+                  1: [2],
+                  2: [3],
+                  3: [4],
+                  4: [1]
+                }, secondarySort: true),
+            throwsCycleException([1, 2, 3, 4]));
       });
-      expect(result.indexOf(1), lessThan(result.indexOf(2)));
-      expect(result.indexOf(1), lessThan(result.indexOf(3)));
-      expect(result.indexOf(1), lessThan(result.indexOf(4)));
-      expect(result.indexOf(4), lessThan(result.indexOf(3)));
-    });
-
-    test('with diamond edges', () {
-      var result = _topologicalSort({
-        1: [2, 3],
-        2: [4],
-        3: [4],
-        4: []
-      });
-      expect(result.indexOf(1), lessThan(result.indexOf(2)));
-      expect(result.indexOf(1), lessThan(result.indexOf(3)));
-      expect(result.indexOf(1), lessThan(result.indexOf(4)));
-      expect(result.indexOf(2), lessThan(result.indexOf(4)));
-      expect(result.indexOf(3), lessThan(result.indexOf(4)));
-    });
-  });
-
-  test('respects custom equality and hash functions', () {
-    expect(
-        _topologicalSort<int>({
-          0: [2],
-          3: [4],
-          5: [6],
-          7: []
-        },
-            equals: (i, j) => (i ~/ 2) == (j ~/ 2),
-            hashCode: (i) => (i ~/ 2).hashCode),
-        equals([
-          0,
-          anyOf([2, 3]),
-          anyOf([4, 5]),
-          anyOf([6, 7])
-        ]));
-  });
-
-  group('throws a CycleException for a graph with', () {
-    test('a one-node cycle', () {
-      expect(
-          () => _topologicalSort({
-                1: [1]
-              }),
-          throwsCycleException([1]));
-    });
-
-    test('a multi-node cycle', () {
-      expect(
-          () => _topologicalSort({
-                1: [2],
-                2: [3],
-                3: [4],
-                4: [1]
-              }),
-          throwsCycleException([1, 2, 3, 4]));
     });
   });
 }
 
 /// Runs a topological sort on a graph represented a map from keys to edges.
 List<T> _topologicalSort<T>(Map<T, List<T>> graph,
-    {bool Function(T, T)? equals, int Function(T)? hashCode}) {
+    {bool Function(T, T)? equals,
+    int Function(T)? hashCode,
+    bool secondarySort = false}) {
   if (equals != null) {
     graph = LinkedHashMap(equals: equals, hashCode: hashCode)..addAll(graph);
   }
   return topologicalSort(graph.keys, (node) {
     expect(graph, contains(node));
     return graph[node]!;
-  }, equals: equals, hashCode: hashCode);
+  },
+      equals: equals,
+      hashCode: hashCode,
+      secondarySort:
+          secondarySort ? (a, b) => (a as Comparable<T>).compareTo(b) : null);
 }


### PR DESCRIPTION
This makes it possible to enforce a topological sort but ensure that
within that, existing nodes are sorted lexically as much as possible.