### PR TITLE
Normalize changelog formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,19 @@
 # 2.3.0
 
 - Add a `transitiveClosure` function.
-
 - Make `stronglyConnectedComponents` and `topologicalSort` iterative rather than
   recursive to avoid stack overflows on very large graphs.
-
 - Require Dart 2.18
 
 # 2.2.0
 
-* Add a `secondarySort` parameter to the `topologicalSort()` function which
+- Add a `secondarySort` parameter to the `topologicalSort()` function which
   applies an additional lexical sort where that doesn't break the topological
   sort.
 
 # 2.1.0
 
-* Add a `topologicalSort()` function.
+- Add a `topologicalSort()` function.
 
 # 2.0.0
 


### PR DESCRIPTION
Use `-` over `*` and avoid extra line breaks for consistency.
